### PR TITLE
Update eca_reponse to eca_response

### DIFF
--- a/python-package/quantum_forest/QForest.py
+++ b/python-package/quantum_forest/QForest.py
@@ -46,7 +46,7 @@ class QForest_config:
 
         self.err_relative = False
         self.task = "train"
-        self.attention_alg = "eca_reponse"       # 'eca_input'
+        self.attention_alg = "eca_response"       # 'eca_input'
 
         self.nMostEpochs = 1000
         self.depth, self.batch_size, self.nTree, self.response_dim, self.nLayers = 5, 256, 256, 8, 1


### PR DESCRIPTION
I found this as a spelling mistake. Because of "eca_reponse" it causes ValueError: INVALID self.config.attention_alg = eca_reponse
I've changed it to "eca_response" and the error got resolved.